### PR TITLE
Add constructor accepting both TxSignService and TransactionReceiptPr…

### DIFF
--- a/core/src/main/java/org/web3j/tx/FastRawTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/FastRawTransactionManager.java
@@ -57,6 +57,14 @@ public class FastRawTransactionManager extends RawTransactionManager {
         super(web3j, credentials, chainId, transactionReceiptProcessor);
     }
 
+    public FastRawTransactionManager(
+            Web3j web3j,
+            TxSignService txSignService,
+            long chainId,
+            TransactionReceiptProcessor transactionReceiptProcessor) {
+        super(web3j, txSignService, chainId, transactionReceiptProcessor);
+    }
+
     @Override
     protected synchronized BigInteger getNonce() throws IOException {
         if (nonce.signum() == -1) {

--- a/core/src/main/java/org/web3j/tx/RawTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/RawTransactionManager.java
@@ -77,6 +77,18 @@ public class RawTransactionManager extends TransactionManager {
     }
 
     public RawTransactionManager(
+            Web3j web3j,
+            TxSignService txSignService,
+            long chainId,
+            TransactionReceiptProcessor transactionReceiptProcessor) {
+        super(transactionReceiptProcessor, txSignService.getAddress());
+
+        this.web3j = web3j;
+        this.chainId = chainId;
+        this.txSignService = txSignService;
+    }
+
+    public RawTransactionManager(
             Web3j web3j, Credentials credentials, long chainId, int attempts, long sleepDuration) {
         super(web3j, attempts, sleepDuration, credentials.getAddress());
 


### PR DESCRIPTION
# PR Description
## What does this PR do?
This PR adds missing constructors to both RawTransactionManager and FastRawTransactionManager classes that accept both TxSignService and TransactionReceiptProcessor parameters.
## Where should the reviewer start?
The reviewer should examine the changes in:
core/src/main/java/org/web3j/tx/RawTransactionManager.java - Added a constructor accepting both TxSignService and TransactionReceiptProcessor
core/src/main/java/org/web3j/tx/FastRawTransactionManager.java - Added a constructor accepting both TxSignService and TransactionReceiptProcessor
## Why is it needed?
Before this PR, users had to choose between using a custom TxSignService or a custom TransactionReceiptProcessor, but couldn't use both simultaneously. This enhancement provides greater flexibility for configuring transaction managers, allowing users to:
Customize how transactions are signed (via TxSignService)
Customize how transaction receipts are processed (via TransactionReceiptProcessor)
Do both at the same time
This is especially valuable for users with custom transaction signing requirements (such as HSM integration) who also need control over transaction receipt processing.